### PR TITLE
Feat/kaniko dir config option

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -182,6 +182,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipTLSVerifyPull, "skip-tls-verify-pull", "", false, "Pull from insecure registry ignoring TLS verify")
 	RootCmd.PersistentFlags().IntVar(&opts.PushRetry, "push-retry", 0, "Number of retries for the push operation")
 	RootCmd.PersistentFlags().IntVar(&opts.ImageFSExtractRetry, "image-fs-extract-retry", 0, "Number of retries for image FS extraction")
+	RootCmd.PersistentFlags().StringVarP(&opts.KanikoDir, "kaniko-dir", "k", "/kaniko", "Path to the kaniko directory")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tarPath", "", "", "Path to save the image in as a tarball instead of pushing")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -290,16 +290,16 @@ func resolveEnvironmentBuildArgs(arguments []string, resolver func(string) strin
 // copy Dockerfile to /kaniko/Dockerfile so that if it's specified in the .dockerignore
 // it won't be copied into the image
 func copyDockerfile() error {
-	if _, err := util.CopyFile(opts.DockerfilePath, constants.DockerfilePath, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
+	if _, err := util.CopyFile(opts.DockerfilePath, config.DockerfilePath, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
 		return errors.Wrap(err, "copying dockerfile")
 	}
 	dockerignorePath := opts.DockerfilePath + ".dockerignore"
 	if util.FilepathExists(dockerignorePath) {
-		if _, err := util.CopyFile(dockerignorePath, constants.DockerfilePath+".dockerignore", util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
+		if _, err := util.CopyFile(dockerignorePath, config.DockerfilePath+".dockerignore", util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
 			return errors.Wrap(err, "copying Dockerfile.dockerignore")
 		}
 	}
-	opts.DockerfilePath = constants.DockerfilePath
+	opts.DockerfilePath = config.DockerfilePath
 	return nil
 }
 

--- a/pkg/buildcontext/azureblob.go
+++ b/pkg/buildcontext/azureblob.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
+	kConfig "github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 )
@@ -55,7 +56,7 @@ func (b *AzureBlob) UnpackTarFromBuildContext() (string, error) {
 	}
 
 	// Create directory and target file for downloading the context file
-	directory := constants.BuildContextDir
+	directory := kConfig.BuildContextDir
 	tarPath := filepath.Join(directory, constants.ContextTar)
 	file, err := util.CreateTargetTarfile(tarPath)
 	if err != nil {

--- a/pkg/buildcontext/gcs.go
+++ b/pkg/buildcontext/gcs.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+	kConfig "github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -36,7 +37,7 @@ type GCS struct {
 
 func (g *GCS) UnpackTarFromBuildContext() (string, error) {
 	bucket, item := util.GetBucketAndItem(g.context)
-	return constants.BuildContextDir, unpackTarFromGCSBucket(bucket, item, constants.BuildContextDir)
+	return kConfig.BuildContextDir, unpackTarFromGCSBucket(bucket, item, kConfig.BuildContextDir)
 }
 
 func UploadToBucket(r io.Reader, dest string) error {

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -19,9 +19,7 @@ package buildcontext
 import (
 	"errors"
 	"fmt"
-	"os"
-	"strings"
-
+	kConfig "github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -31,8 +29,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/sirupsen/logrus"
-
-	"github.com/GoogleContainerTools/kaniko/pkg/constants"
+	"os"
+	"strings"
 )
 
 const (
@@ -57,7 +55,7 @@ type Git struct {
 
 // UnpackTarFromBuildContext will provide the directory where Git Repository is Cloned
 func (g *Git) UnpackTarFromBuildContext() (string, error) {
-	directory := constants.BuildContextDir
+	directory := kConfig.BuildContextDir
 	parts := strings.Split(g.context, "#")
 	url := getGitPullMethod() + "://" + parts[0]
 	options := git.CloneOptions{

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -19,6 +19,9 @@ package buildcontext
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
+
 	kConfig "github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
@@ -29,8 +32,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/sirupsen/logrus"
-	"os"
-	"strings"
 )
 
 const (

--- a/pkg/buildcontext/https.go
+++ b/pkg/buildcontext/https.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
+	kConfig "github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -39,7 +40,7 @@ func (h *HTTPSTar) UnpackTarFromBuildContext() (directory string, err error) {
 	logrus.Info("Retrieving https tar file")
 
 	// Create directory and target file for downloading the context file
-	directory = constants.BuildContextDir
+	directory = kConfig.BuildContextDir
 	tarPath := filepath.Join(directory, constants.ContextTar)
 	file, err := util.CreateTargetTarfile(tarPath)
 	if err != nil {

--- a/pkg/buildcontext/s3.go
+++ b/pkg/buildcontext/s3.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	kConfig "github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/aws/aws-sdk-go/aws"
@@ -56,7 +57,7 @@ func (s *S3) UnpackTarFromBuildContext() (string, error) {
 		return bucket, err
 	}
 	downloader := s3manager.NewDownloader(sess)
-	directory := constants.BuildContextDir
+	directory := kConfig.BuildContextDir
 	tarPath := filepath.Join(directory, constants.ContextTar)
 	if err := os.MkdirAll(directory, 0750); err != nil {
 		return directory, err

--- a/pkg/buildcontext/tar.go
+++ b/pkg/buildcontext/tar.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleContainerTools/kaniko/pkg/constants"
+	kConfig "github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -34,7 +34,7 @@ type Tar struct {
 
 // UnpackTarFromBuildContext unpack the compressed tar file
 func (t *Tar) UnpackTarFromBuildContext() (string, error) {
-	directory := constants.BuildContextDir
+	directory := kConfig.BuildContextDir
 	if err := os.MkdirAll(directory, 0750); err != nil {
 		return "", errors.Wrap(err, "unpacking tar from build context")
 	}

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -18,8 +18,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"os"
+
+	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 )
 
 var RootDir string

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -17,15 +17,35 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
+	"os"
 )
 
 var RootDir string
-var KanikoDir string
+
+// KanikoDir is the path to the Kaniko directory
+var KanikoDir = func() string {
+	if kd, ok := os.LookupEnv("KANIKO_DIR"); ok {
+		return kd
+	}
+	return "/kaniko"
+}()
+
+// DockerfilePath is the path the Dockerfile is copied to
+var DockerfilePath = fmt.Sprintf("%s/Dockerfile", KanikoDir)
+
+// BuildContextDir is the directory a build context will be unpacked into,
+// for example, a tarball from a GCS bucket will be unpacked here
+var BuildContextDir = fmt.Sprintf("%s/buildcontext/", KanikoDir)
+
+// KanikoIntermediateStagesDir is where we will store intermediate stages
+// as tarballs in case they are needed later on
+var KanikoIntermediateStagesDir = fmt.Sprintf("%s/stages/", KanikoDir)
+
 var IgnoreListPath string
 
 func init() {
 	RootDir = constants.RootDir
-	KanikoDir = constants.KanikoDir
 	IgnoreListPath = constants.IgnoreListPath
 }

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -58,6 +58,7 @@ type KanikoOptions struct {
 	CustomPlatform         string
 	Bucket                 string
 	TarPath                string
+	KanikoDir              string
 	Target                 string
 	CacheRepo              string
 	DigestFile             string

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,30 +16,21 @@ limitations under the License.
 
 package constants
 
+import (
+// "fmt"
+// "os"
+)
+
 const (
 	// RootDir is the path to the root directory
 	RootDir = "/"
-
-	// KanikoDir is the path to the Kaniko directory
-	KanikoDir = "/kaniko"
 
 	IgnoreListPath = "/proc/self/mountinfo"
 
 	Author = "kaniko"
 
-	// DockerfilePath is the path the Dockerfile is copied to
-	DockerfilePath = "/kaniko/Dockerfile"
-
 	// ContextTar is the default name of the tar uploaded to GCS buckets
 	ContextTar = "context.tar.gz"
-
-	// BuildContextDir is the directory a build context will be unpacked into,
-	// for example, a tarball from a GCS bucket will be unpacked here
-	BuildContextDir = "/kaniko/buildcontext/"
-
-	// KanikoIntermediateStagesDir is where we will store intermediate stages
-	// as tarballs in case they are needed later on
-	KanikoIntermediateStagesDir = "/kaniko/stages"
 
 	// Various snapshot modes:
 	SnapshotModeTime = "time"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,11 +16,6 @@ limitations under the License.
 
 package constants
 
-import (
-// "fmt"
-// "os"
-)
-
 const (
 	// RootDir is the path to the root directory
 	RootDir = "/"

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -829,7 +829,7 @@ func saveStageAsTarball(path string, image v1.Image) error {
 	if err != nil {
 		return err
 	}
-	tarPath := filepath.Join(constants.KanikoIntermediateStagesDir, path)
+	tarPath := filepath.Join(config.KanikoIntermediateStagesDir, path)
 	logrus.Infof("Storing source image from stage %s at path %s", path, tarPath)
 	if err := os.MkdirAll(filepath.Dir(tarPath), 0750); err != nil {
 		return err

--- a/pkg/executor/copy_multistage_test.go
+++ b/pkg/executor/copy_multistage_test.go
@@ -177,7 +177,6 @@ func setupMultistageTests(t *testing.T) (string, func()) {
 	}
 	config.IgnoreListPath = mFile
 	return testDir, func() {
-		config.KanikoDir = constants.KanikoDir
 		config.RootDir = constants.RootDir
 		config.IgnoreListPath = constants.IgnoreListPath
 	}

--- a/pkg/image/image_util.go
+++ b/pkg/image/image_util.go
@@ -92,7 +92,7 @@ func RetrieveSourceImage(stage config.KanikoStage, opts *config.KanikoOptions) (
 }
 
 func tarballImage(index int) (v1.Image, error) {
-	tarPath := filepath.Join(constants.KanikoIntermediateStagesDir, strconv.Itoa(index))
+	tarPath := filepath.Join(config.KanikoIntermediateStagesDir, strconv.Itoa(index))
 	logrus.Infof("Base image from previous stage %d found, using saved tar at path %s", index, tarPath)
 	return tarball.ImageFromPath(tarPath, nil)
 }


### PR DESCRIPTION
# DRAFT TO MY OWN MAIN BRANCH FOR FEEDBACK/HELP


### Thoughts

Moving `KanikoDir` away from `/kaniko` and being configurable means that we need to move it out of `constants.go`, it is no longer a constant after all; however, there are other variables which also implicitly used this, namely `DockerfilePath`, `BuildContextDir`, and `KanikoIntermediateStagesDir`, meaning that these also need to be adjusted inline with this change.

By changing this, we also introduce a bit of difficulty (I've not been able to figure it out yet) on how the `KanikoDir` is populated for the `cmd/executor` functionality. The initial implementation wasn't configurable, so using the constant is absolutely fine, but making it configurable means we need to have it adjusted in some way at first - I've opted for using an env var to test things out, but this led me to see that we have a bit of a chicken/egg situation, i.e. the `KANIKO_DIR` is used to modify its value from the `init.go` file, but we'd also like to have a nice `--kaniko-dir` flag that can be passed by users - the env var is taking precedence here, as would another implementation in this manner - this leads me to believe there is a simpler way to achieve it.